### PR TITLE
Make gulp-mocha compatible with watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 'use strict';
 var es = require('event-stream');
 var Mocha = require('mocha');
+var path = require('path');
 
 module.exports = function (options) {
 	var mocha = new Mocha(options);
 
 	return es.through(function (file) {
+		delete require.cache[require.resolve(path.resolve(file.path))];
 		mocha.addFile(file.path);
 		this.emit('data', file);
 	}, function () {


### PR DESCRIPTION
Since mocha uses `require` to load tests - we need either run mocha in
spawned process or clear requires cache.
