### PR TITLE
Show how many tests failed after each run

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,10 @@ module.exports = function (options) {
 			mocha.run(function (errCount) {
 				duplex.push(file);
 				errorCount += errCount;
+				if (errorCount) {
+                    console.log('  ' + gutil.colors.red(errorCount) + ' failing');
+                    console.log();
+                }
 				done();
 			}.bind(this));
 		} catch (err) {


### PR DESCRIPTION
In streaming mode it is very convenient to show how many tests already failed:

![screen shot 2014-01-10 at 11 37 39](https://f.cloud.github.com/assets/365089/1884991/c749750c-79b9-11e3-945d-c1af886dacb4.png)
