### PR TITLE
Add require option to accept AltJS

### DIFF
--- a/fixture-fail.coffee
+++ b/fixture-fail.coffee
@@ -1,0 +1,4 @@
+assert = require 'assert'
+
+it 'should fail', ->
+	assert no

--- a/fixture-pass.coffee
+++ b/fixture-pass.coffee
@@ -1,0 +1,4 @@
+assert = require 'assert'
+
+it 'should pass', ->
+	assert yes

--- a/index.js
+++ b/index.js
@@ -9,7 +9,16 @@ module.exports = function (options) {
 	var errorCount = 0;
 
 	duplex._write = function (file, encoding, done) {
-		var mocha = new Mocha(options);
+		var mocha;
+
+		// Load provided modules as the same to mocha's --require
+		if (options && Array.isArray(options.require)) {
+			options.require.forEach(function (mod) {
+				require(mod);
+			});
+		}
+
+		mocha = new Mocha(options);
 		delete require.cache[require.resolve(path.resolve(file.path))];
 		mocha.addFile(file.path);
 

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   "dependencies": {
     "gulp-util": "~2.2.0",
     "mocha": "~1"
+  },
+  "devDependencies": {
+    "coffee-script": "~1.6.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -36,3 +36,34 @@ it('should run unit test and fail', function (cb) {
 	stream.write(new gutil.File({path: 'fixture-fail.js'}));
 	stream.end();
 });
+
+it('should run unit test written in coffee-script and pass', function (cb) {
+	var stream = mocha({ require: [ 'coffee-script' ] });
+
+	process.stdout.write = function (str) {
+		if (/1 passing/.test(str)) {
+			assert(true);
+			process.stdout.write = out;
+			cb();
+		}
+	};
+
+	stream.write(new gutil.File({path: 'fixture-pass.coffee'}));
+	stream.end();
+});
+
+it('should run unit test written in coffee-script and fail', function (cb) {
+	var stream = mocha({ require: [ 'coffee-script' ] });
+
+	process.stderr.write = function (str) {
+		if (/1 failing/.test(str)) {
+			assert(true);
+			process.stderr.write = err;
+			cb();
+		}
+	};
+
+	stream.on('error', function () {});
+	stream.write(new gutil.File({path: 'fixture-fail.coffee'}));
+	stream.end();
+});


### PR DESCRIPTION
By specifying require: [ 'coffee-script' ], we can use test files written
in coffee-script. This `require` option is derived from mocha's `require`
option.
