### PR TITLE
Reset require cache back it original state on each run to avoid caching.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,12 @@ var Mocha = require('mocha');
 
 module.exports = function (options) {
 	var mocha = new Mocha(options);
+	var cache = {};
+
+	for (var key in require.cache)
+		cache[key] = true;
+
 	return through2.obj(function (file, enc, cb) {
-		delete require.cache[require.resolve(path.resolve(file.path))];
 		mocha.addFile(file.path);
 		this.push(file);
 		cb();
@@ -17,6 +21,10 @@ module.exports = function (options) {
 				if (errCount > 0) {
 					this.emit('error', new gutil.PluginError('gulp-mocha', errCount + ' ' + (errCount === 1 ? 'test' : 'tests') + ' failed.'));
 				}
+
+				for (var key in require.cache)
+					if (!cache[key])
+						delete require.cache[key];
 
 				cb();
 			}.bind(this));


### PR DESCRIPTION
The strategy of deleting test file from require cache doesn't seem to work because the files that the test has required remain in cache. This approach seem to be working in terms of resetting cache.

Thoughts?
