### PR TITLE
Call process.exit after finishing running tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = function (options) {
 				}
 
 				cb();
+				process.exit(errCount);
 			}.bind(this));
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-mocha', err));


### PR DESCRIPTION
Mocha is doing it in [a similar way](https://github.com/visionmedia/mocha/blob/master/bin/_mocha#L359).

It should resolve #28. I'm running tests with supertest and it exits correctly now.
