### PR TITLE
Return stream in example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 
 gulp.task('default', function () {
-	gulp.src('test.js')
+	return gulp.src('test.js')
 		.pipe(mocha({reporter: 'nyan'}));
 });
 ```


### PR DESCRIPTION
Example return the stream of processed tests so gulp treats the task as asynchronous and wait for it to complete before reporting so: plugin duration is relevant and test results are displayed before the plugin is marked as completed.
