### PR TITLE
Checked for null before adding.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = function (options) {
 	}
 
 	return through2.obj(function (file, enc, cb) {
-		mocha.addFile(file.path);
+		if(!file.isNull())
+			mocha.addFile(file.path);
 		this.push(file);
 		cb();
 	}, function (cb) {


### PR DESCRIPTION
The [gulp docs](https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/guidelines.md) say: `If file.contents is null (non-read) just ignore the file and pass it along`. I ran into a situation like the following:

```
gulp.src(glob).pipe(filterMethod()).pipe(mocha());
```

And mocha was loading the files I was filtering out.
