### PR TITLE
Store the require cache a little later.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,6 @@ var Mocha = require('mocha');
 
 module.exports = function (options) {
 	var mocha = new Mocha(options);
-	var cache = {};
-
-	for (var key in require.cache) {
-		cache[key] = true;
-	}
 
 	return through2.obj(function (file, enc, cb) {
 		mocha.addFile(file.path);
@@ -18,6 +13,11 @@ module.exports = function (options) {
 		cb();
 	}, function (cb) {
 		try {
+			var cache = {};
+			for (var key in require.cache) {
+				cache[key] = true;
+			}
+
 			mocha.run(function (errCount) {
 				if (errCount > 0) {
 					this.emit('error', new gutil.PluginError('gulp-mocha', errCount + ' ' + (errCount === 1 ? 'test' : 'tests') + ' failed.'));


### PR DESCRIPTION
I mentioned in #16 that I had issues with the retiring of the `require` cache. Inspecting the cache, then asynchronously restoring it to a previous state appears to be dangerous (though it doesn't feel that it should be).

Saving the cache values a little later resolved my issue (maybe not perfectly), but I suspect that it will only resolve the issue the majority of the time, and that this won't fix 100% of issues that could arise because of this.
