### PR TITLE
Don't dispose domain object

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ module.exports = function (options) {
 		var d = domain.create();
 
 		function handleException(e) {
-			d.dispose();
 			clearCache();
 			stream.emit('error', new gutil.PluginError('gulp-mocha', e));
 			cb();
@@ -40,7 +39,6 @@ module.exports = function (options) {
 		d.run(function () {
 			try {
 				mocha.run(function (errCount) {
-					d.dispose();
 					clearCache();
 					if (errCount > 0) {
 						stream.emit('error', new gutil.PluginError('gulp-mocha', errCount + ' ' + (errCount === 1 ? 'test' : 'tests') + ' failed.'));


### PR DESCRIPTION
Domain object disposal causes gulp process to be terminated prematurely when running on Windows and gulp output is piped to another process (pipe doesn't get a chance to pick up buffered data).

As per @isaacs, `dispose` is usually not required and will be deprecated soon. See [here](https://github.com/joyent/node/issues/5018) and [here](https://github.com/joyent/node/issues/4805#issuecomment-13862816).

Thanks @jgoz for resolving the piping issue.
