### PR TITLE
Update docs to reflect `spec` as new default reporter

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ The interface to use.
 #### options.reporter
 
 Type: `string`  
-Default: `dot`  
+Default: `spec` | `dot` prior to mocha v1.21.0  
 Values: [reporters](https://github.com/visionmedia/mocha/tree/master/lib/reporters)
 
 The reporter that will be used.


### PR DESCRIPTION
As of v1.21.0, `mocha`s default report is `spec`. Updated readme to reflect that change.
