### PR TITLE
Switch to through from through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "mocha": "^1",
-    "through2": "^0.6.1"
+    "through": "^2.3.4"
   }
 }


### PR DESCRIPTION
Through2 emits end after _flush function is completed. This causes wrong interpretation of end of the stream in orchestrator. Through in other hand give possibility to not emit `end`, if something goes wrong in flush function.

This fixes #45.
