### PR TITLE
Pass async test AssertionError exception to Mocha

### DIFF
--- a/fixture-async.js
+++ b/fixture-async.js
@@ -1,0 +1,9 @@
+/* global it */
+'use strict';
+var assert = require('assert');
+
+it('should fail after timeout', function (done) {
+	setTimeout(function () {
+		assert(false);
+	}, 10);
+});

--- a/index.js
+++ b/index.js
@@ -28,16 +28,21 @@ module.exports = function (options) {
 	}, function () {
 		var stream = this;
 		var d = domain.create();
+		var runner;
 
 		function handleException(err) {
-			clearCache();
-			stream.emit('error', new gutil.PluginError('gulp-mocha', err));
+			if (err.name === 'AssertionError' && runner) {
+				runner.uncaught(err);
+			} else {
+				clearCache();
+				stream.emit('error', new gutil.PluginError('gulp-mocha', err));
+			}
 		}
 
 		d.on('error', handleException);
 		d.run(function () {
 			try {
-				var runner = mocha.run(function (errCount) {
+				runner = mocha.run(function (errCount) {
 					clearCache();
 
 					if (errCount > 0) {


### PR DESCRIPTION
Exceptions are caught by gulp-mocha and translated into a gulp PluginError.
However, some are valid from an asynchronous Mocha tests and if they are not
passed back to the Mocha runner the tests fail from timeout. It should at least
pass AssertionError back to Mocha to make gulp-mocha and mocha output
consistent.

Without this commit the extraneous PluginError kills the gulp task before Mocha
finishes. It also causes gulp watch tasks to "finish" before the Mocha runner
completes.

This commit calls the internal "uncaught" function of the Mocha runner. There
may be a better way. However, it seems this is how Mocha's runner already works,
it is just gulp-mocha catches it before Mocha's uncaught exception listener gets
a hold of it.
