### PR TITLE
Fix stack display when using plumber

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (options) {
 				runner.uncaught(err);
 			} else {
 				clearCache();
-				stream.emit('error', new gutil.PluginError('gulp-mocha', err));
+				stream.emit('error', new gutil.PluginError('gulp-mocha', err, {stack: err.stack, showStack: true}));
 			}
 		}
 


### PR DESCRIPTION
When an exception is thrown and caught by the global error handler and plumber is enabled on tasks, the stack trace and other debugging info is lost:

```
[01:40:17] Plumber found unhandled error:
 TypeError in plugin 'gulp-mocha'
Message:
    Cannot call method 'replace' of undefined
Details:
    domain: [object Object]
    domainThrown: true
    1) should load js+css on initial route
```

By passing the stack and showStack flag, the most important trace, the original throw, is properly logged.

```
[01:46:54] Plumber found unhandled error:
 TypeError in plugin 'gulp-mocha'
Message:
    Cannot call method 'replace' of undefined
Details:
    domain: [object Object]
    domainThrown: true
Stack:
TypeError: Cannot call method 'replace' of undefined
    at Tapable.replacePathVariables (/Users/kpdecker/dev/public/webpack/lib/TemplatedPathPlugin.js:66:4)
    at Tapable.applyPlugins [as applyPluginsWaterfall] (/Users/kpdecker/dev/public/webpack/node_modules/tapable/lib/Tapable.js:37:47)
    at Tapable.<anonymous> (/Users/kpdecker/dev/walmart/zeus/pack/lib/templates/main-template.js:9:4044)
    at /Users/kpdecker/dev/walmart/zeus/pack/node_modules/lodash/dist/lodash.js:901:23
    at Function.forEach (/Users/kpdecker/dev/walmart/zeus/pack/node_modules/lodash/dist/lodash.js:3297:15)
    at Tapable.<anonymous> (/Users/kpdecker/dev/walmart/zeus/pack/lib/templates/main-template.js:9:3907)
    at Tapable.applyPlugins [as applyPluginsWaterfall] (/Users/kpdecker/dev/public/webpack/node_modules/tapable/lib/Tapable.js:37:47)
    at Tapable.MainTemplate.render (/Users/kpdecker/dev/public/webpack/lib/MainTemplate.js:103:16)
    at Tapable.createChunkAssets (/Users/kpdecker/dev/public/webpack/lib/Compilation.js:751:32)
    at Tapable.<anonymous> (/Users/kpdecker/dev/public/webpack/lib/Compilation.js:509:8)
    1) should load js+css on initial route
```
