### PR TITLE
Bugfix affecting reporters with async `.done` functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,13 +49,8 @@ module.exports = function (options) {
 						stream.emit('error', new gutil.PluginError('gulp-mocha', errCount + ' ' + (errCount === 1 ? 'test' : 'tests') + ' failed.', {
 							showStack: false
 						}));
-					} else if (!hasTests) {
-						stream.emit('end');
 					}
-				});
 
-				runner.on('end', function () {
-					clearCache();
 					stream.emit('end');
 				});
 			} catch (err) {


### PR DESCRIPTION
### Observed Bug

When using mocha reporters that have async done functions (such as [xunit](https://github.com/mochajs/mocha/blob/master/lib/reporters/xunit.js#L80) when writing to a file) the process does not exit with a non-zero code when there are test failures as it ought to.

### Hypothesis

The stream from gulp is being closed before gulp-mocha writes the error to the stream since the error is emitted in the done callback (https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L412) but `end` is emitted upon the runner `end` event.  This likely wasn't seen previously since xunit is the only built-in reporter that attaches a done function (and that function is only async when `reporterOptions.output` is set to a file).

### Reproduction / Testing

In the gulp file:

```js
var gulp = require('gulp');
var mocha = require('gulp-mocha');

gulp.task('mocha', function() {
    gulp.src(['test/**/*.js']) // points to failing test(s)
        .pipe(mocha({
            reporter: 'xunit',
            reporterOptions: {
                output: '/tmp/mocha-xunit-report.xml'
            }
        }));
});
```

* Provide gulp-mocha a stream of test files with at least one failure among them
* Use xunit reporter with `output` reporter option set to file path

2. `gulp mocha`
3. Observe that gulp exits with a zero exit code
4. Link this PR into `node_modules`
5. `gulp mocha`
6. Observe that gulp exits with a non-zero exit code
7. Change reporter to spec, dot, etc., run again, and observe that those runners still function correctly

### Notes

The automated tests will fail, but the are the same failures as seen on latest master (https://travis-ci.org/sindresorhus/gulp-mocha/builds/48154728)