### PR TITLE
enabled dump option to gulp-mocha

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,9 @@ var domain = require('domain');
 var gutil = require('gulp-util');
 var through = require('through');
 var Mocha = require('mocha');
+var fs = require('fs');
+var mkdirpSync = require('mkdirp').sync;
+var path = require('path');
 
 module.exports = function (options) {
 	var mocha = new Mocha(options);
@@ -29,8 +32,25 @@ module.exports = function (options) {
 		var stream = this;
 		var d = domain.create();
 		var runner;
+		var dumpFile;
+		var stdoutWrite;
+
+		function cleanupDump() {
+			// close the file if it was opened
+			if (dumpFile) {
+				fs.closeSync(dumpFile);
+				dumpFile = void 0;
+			}
+
+			// restore original stdout.write method
+			if (typeof stdoutWrite === 'function') {
+				process.stdout.write = stdoutWrite;
+				stdoutWrite = void 0;
+			}
+		}
 
 		function handleException(err) {
+			cleanupDump();
 			if (err.name === 'AssertionError' && runner) {
 				runner.uncaught(err);
 			} else {
@@ -41,9 +61,26 @@ module.exports = function (options) {
 
 		d.on('error', handleException);
 		d.run(function () {
+			if (options.dump) {
+				// creates the dump file if required
+				mkdirpSync(path.dirname(options.dump));
+				dumpFile = fs.openSync(options.dump, 'w');
+
+				// patch the stdout.write method to dump the output into a file
+				stdoutWrite = process.stdout.write;
+				process.stdout.write = function(chunk) {
+					if (options.dump && dumpFile) {
+						fs.writeSync(dumpFile, chunk);
+					}
+
+					return stdoutWrite.apply(this, arguments);
+				};
+			}
+
 			try {
 				runner = mocha.run(function (errCount) {
 					clearCache();
+					cleanupDump();
 
 					if (errCount > 0) {
 						stream.emit('error', new gutil.PluginError('gulp-mocha', errCount + ' ' + (errCount === 1 ? 'test' : 'tests') + ' failed.', {
@@ -56,6 +93,7 @@ module.exports = function (options) {
 
 				runner.on('end', function () {
 					clearCache();
+					cleanupDump();
 					stream.emit('end');
 				});
 			} catch (err) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
+    "mkdirp": "^0.5.0",
     "mocha": "^2.0.1",
     "through": "^2.3.4"
   }


### PR DESCRIPTION
when using `gulp-mocha` and integrating with `jenkins` depending how is the integration done there is a need to dump the generated report to a file.
`gulp-mocha-phantomjs` allows it through a `dump` option, this pull request enables a similar `dump` option to `gulp-mocha`.

usage:
```js
    var gulp = require( 'gulp' );
    var path = require( 'path' );
    var mocha = require( 'gulp-mocha' );

    gulp.task( 'test', function() {
        return gulp.src( [ 'path/to/specs/**/*.*' ], { read: false } )
            .pipe( mocha, {
                reporter: 'xunit',
                dump: path.resolve( __dirname, '../../', 'tests/log/mocha.xml' )
            } );
    } );
```