### PR TITLE
Emit `end` after non-assertion errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = function (options) {
 			} else {
 				clearCache();
 				stream.emit('error', new gutil.PluginError('gulp-mocha', err, {stack: err.stack, showStack: true}));
+				stream.emit('end');
 			}
 		}
 

--- a/test.js
+++ b/test.js
@@ -127,3 +127,16 @@ it('should pass async AssertionError to mocha', function (done) {
 	stream.write(new gutil.File({path: 'fixture-async.js'}));
 	stream.end();
 });
+
+it('should emit end after mocha threw', function (done) {
+	var stream = mocha();
+	var threw = false;
+	stream.once('error', function () {
+		threw = true;
+	}).once('end', function () {
+		assert(threw);
+		done();
+	});
+	stream.write(new gutil.File({path: 'fixture-throws.js'}));
+	stream.end();
+});


### PR DESCRIPTION
The stream would never end when Mocha found a syntax error or uncaught exception, which breaks incremental builds such as gulp-plumber + gulp-watch.
This PR will fix it.

cc @sindresorhus @floatdrop 