### PR TITLE
hack to fix Module did not self-register errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (opts) {
 
 	function clearCache() {
 		for (var key in require.cache) {
-			if (!cache[key] && !key.match(/.*\.node$/)) {
+			if (!cache[key] && !/\.node$/.test(key)) {
 				delete require.cache[key];
 			}
 		}

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function (opts) {
 
 	function clearCache() {
 		for (var key in require.cache) {
-			if (!cache[key]) {
+			if (!cache[key] && !key.match(/.*\.node$/)) {
 				delete require.cache[key];
 			}
 		}


### PR DESCRIPTION
It seems that removing .node references from the require cache leads to
issues with and error "Module did not self-register". Hence why if you
use bcrypt or anything you end up having to order your requires and
putting modules into your gulpfile that aren't needed in your gulp
script.

This is a temporary fix but it works
ref: sindresorhus/gulp-mocha #86 

I've had this using modules such as Heapdump, bcrypt and more, basically anything that uses node-gyp bindings.

Not sure how to create a test case for this.