### PR TITLE
Support for relative paths for require.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var gutil = require('gulp-util');
 var through = require('through');
 var Mocha = require('mocha');
 var plur = require('plur');
+var fs = require('fs');
+var path = require('path');
 
 module.exports = function (opts) {
 	opts = opts || {};
@@ -24,7 +26,12 @@ module.exports = function (opts) {
 	}
 
 	if (opts.require && opts.require.length) {
-		opts.require.forEach(require);
+		opts.require.forEach(function(mod) {
+			var isFile = fs.existsSync(mod) || fs.existsSync(mod + '.js');
+			if (isFile)
+				mod = path.resolve(mod);
+			require(mod);
+		});
 	}
 
 	return through(function (file) {


### PR DESCRIPTION
Noticed that I couldn't use the require option for local paths in the running working directory. Didn't have this fault when using grunt-mocha-test so I thought that it could be useful for gulp-mocha. 

This commit is similar to the commit in this PR: https://github.com/sindresorhus/gulp-mocha/pull/95
which was closed. This commit is different since it has a smaller impact and aims to solve a different problem.