### PR TITLE
listen to mocha events

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,18 @@ module.exports = function (opts) {
 		var self = this;
 		var d = domain.create();
 		var runner;
+		var events = ['start', 'end', 'suite', 'suite end', 'test', 'test end', 'hook', 'hook end',
+									'pass', 'fail', 'pending' ];
+
+		function attachEventListeners(runner) {
+			var obj = Object.keys(opts);
+				for (var prop in obj) {
+					var method = obj[prop];
+					if (events.indexOf(method) > -1) {
+						runner.on(method, opts[method]);
+					}
+				}
+		}
 
 		function handleException(err) {
 			if (err.name === 'AssertionError' && runner) {
@@ -64,6 +76,9 @@ module.exports = function (opts) {
 
 					self.emit('end');
 				});
+
+				attachEventListeners(runner);
+
 			} catch (err) {
 				handleException(err);
 			}


### PR DESCRIPTION
This should fix issue https://github.com/sindresorhus/gulp-mocha/issues/108. Simply attaches event listeners for events that are emitted by Mocha when hooks are completed: 

 *   - `start`  execution started
 *   - `end`  execution complete
 *   - `suite`  (suite) test suite execution started
 *   - `suite end`  (suite) all tests (and sub-suites) have finished
 *   - `test`  (test) test execution started
 *   - `test end`  (test) test completed
 *   - `hook`  (hook) hook execution started
 *   - `hook end`  (hook) hook complete
 *   - `pass`  (test) test passed
 *   - `fail`  (test, err) test failed
 *   - `pending`  (test) test pending

To listen to the events you would simply pass in a callback for each event you want to listen for. 
In my case it allows me to send my failed tests to a mailer function

    var mocha = require('gulp-mocha');
    var mailer = require('./lib/mailer');

    gulp.task('run-tests', function() {

       var failedTests = [];

       return gulp.src('test/tests.js', { read: false })
           .pipe(mocha({
                   timeout : 15000,
                   reporter: 'spec',
                   fail : function(test, err) {
                       failedTests.push(test);
                   },
                   end : function(test) {
                       if(failedTests.length > 0) {
                           mailer.sendMail(failedTests);
                       }
                   },
           })
       );