### PR TITLE
Report errors during test as failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function (opts) {
 		var runner;
 
 		function handleException(err) {
-			if (err.name === 'AssertionError' && runner) {
+			if (runner) {
 				runner.uncaught(err);
 			} else {
 				clearCache();


### PR DESCRIPTION
Addresses #68 

Without this change, there is a test that should fail, but actually passes in `fixture-throws-uncaught.js` With this change, it fails as expected.