### PR TITLE
Dispose domain after running tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,5 +68,6 @@ module.exports = function (opts) {
 				handleException(err);
 			}
 		});
+		d.dispose();
 	});
 };


### PR DESCRIPTION
Without a dispose call, the error handler remains active.