### PR TITLE
changed file.isNull() to file === null since that does not require us…

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = opts => {
 	const files = [];
 
 	function aggregate(file, encoding, done) {
-		if (file.isNull()) {
+		if (file === null) {
 			done(null, file);
 			return;
 		}


### PR DESCRIPTION
… to actually read the file thus not breaking the old behaviour

This would fix this issue:
https://github.com/sindresorhus/gulp-mocha/issues/152

and allow the current behavior of not forcing the file to be read just as it has worked in <4.0.0