### PR TITLE
Add compiler option description to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -100,6 +100,12 @@ Type: `Array`
 
 Require custom modules before tests are run.
 
+##### compilers
+
+Type: `String`
+
+Specify a compiler (ex. 'js:babel-core/register')
+
 
 ## FAQ
 


### PR DESCRIPTION
I often need to search for the correct use of this option every time a start a new project that uses gulp. I would like this to be in the readme.