### PR TITLE
Forward stderr too

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = opts => {
 
 		if (!opts.suppress) {
 			proc.stdout.pipe(process.stdout);
+			proc.stderr.pipe(process.stderr);
 		}
 	}
 


### PR DESCRIPTION
Forward stderr

```coffee
describe 'errors', ->
  it 'logs errors', ->
    Promise.resolve()
    .then ->
      console.error new Error "Don't swallow me!"
```

```js
describe('errors', function() {
  return it('logs errors', function() {
    return Promise.resolve().then(function() {
      console.error(new Error("Don't swallow me!"));
    });
  });
});
```