### PR TITLE
Convert objects to key value lists. Closes #167

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ module.exports = opts => {
 
 		if (Array.isArray(val)) {
 			opts[key] = val.join(',');
+
+			// Convert an object into comma separated list.
+		} else if (typeof val === 'object') {
+			opts[key] = convertObjectToList(val);
 		}
 	}
 
@@ -61,6 +65,27 @@ module.exports = opts => {
 			proc.stdout.pipe(process.stdout);
 			proc.stderr.pipe(process.stderr);
 		}
+	}
+
+	function objectEntries(object) {
+		const entries = [];
+		for (const key in object) {
+			if (has(object, key)) {
+				const value = object[key];
+				entries.push([key, value]);
+			}
+		}
+		return entries;
+	}
+
+	function convertObjectToList(object) {
+		return objectEntries(object)
+			.reduce((result, current) => result.concat(`${current[0]}=${current[1]}`), [])
+			.join(',');
+	}
+
+	function has(object, prop) {
+		return Object.prototype.hasOwnProperty.call(object, prop);
 	}
 
 	return through.obj(aggregate, flush);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const gutil = require('gulp-util');
 const through = require('through2');
 // TODO: Use execa localDir option when available
 const npmRunPath = require('npm-run-path');
+const utils = require('./utils');
+
+const convertObjectToList = utils.convertObjectToList;
 
 const HUNDRED_MEGABYTES = 1000 * 1000 * 100;
 
@@ -56,36 +59,15 @@ module.exports = opts => {
 			this.emit('_result', result);
 			done();
 		})
-		.catch(err => {
-			this.emit('error', new gutil.PluginError('gulp-mocha', err));
-			done();
-		});
+			.catch(err => {
+				this.emit('error', new gutil.PluginError('gulp-mocha', err));
+				done();
+			});
 
 		if (!opts.suppress) {
 			proc.stdout.pipe(process.stdout);
 			proc.stderr.pipe(process.stderr);
 		}
-	}
-
-	function objectEntries(object) {
-		const entries = [];
-		for (const key in object) {
-			if (has(object, key)) {
-				const value = object[key];
-				entries.push([key, value]);
-			}
-		}
-		return entries;
-	}
-
-	function convertObjectToList(object) {
-		return objectEntries(object)
-			.reduce((result, current) => result.concat(`${current[0]}=${current[1]}`), [])
-			.join(',');
-	}
-
-	function has(object, prop) {
-		return Object.prototype.hasOwnProperty.call(object, prop);
 	}
 
 	return through.obj(aggregate, flush);

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,16 @@
+'use strict';
+const assert = require('assert');
+const utils = require('../utils');
+
+const convertObjectToList = utils.convertObjectToList;
+
+describe('Utils', () => {
+	describe('convertObjectToList', () => {
+		it('produces a comma separated string of k=v', done => {
+			const actual = convertObjectToList({key1: 'value1', key2: 'value2', key99: 'value99'});
+			const expected = 'key1=value1,key2=value2,key99=value99';
+			assert(actual === expected);
+			done();
+		});
+	});
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,18 @@
+function objectEntries(object) {
+	const entries = [];
+	for (const key of Object.keys(object)) {
+		const value = object[key];
+		entries.push([key, value]);
+	}
+	return entries;
+}
+
+function convertObjectToList(object) {
+	return objectEntries(object)
+		.reduce((result, current) => result.concat(`${current[0]}=${current[1]}`), [])
+		.join(',');
+}
+
+module.exports = {
+	convertObjectToList
+};

--- a/utils.js
+++ b/utils.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function objectEntries(object) {
 	const entries = [];
 	for (const key of Object.keys(object)) {


### PR DESCRIPTION
Quick and dirty conversion of object to comma separated list `key1=val1,key2=val2`.