### PR TITLE
Fix `require` option for multiple entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ const npmRunPath = require('npm-run-path');
 
 const HUNDRED_MEGABYTES = 1000 * 1000 * 100;
 
+// List of mocha options that can be specified multiple times
+const MULTIPLE_OPTS = [
+	'require'
+];
+
 module.exports = opts => {
 	opts = Object.assign({
 		colors: true,
@@ -18,7 +23,7 @@ module.exports = opts => {
 	for (const key of Object.keys(opts)) {
 		const val = opts[key];
 
-		if (Array.isArray(val)) {
+		if (MULTIPLE_OPTS.indexOf(key) > 0 && Array.isArray(val)) {
 			opts[key] = val.join(',');
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const npmRunPath = require('npm-run-path');
 
 const HUNDRED_MEGABYTES = 1000 * 1000 * 100;
 
-// List of mocha options that can be specified multiple times
+// Mocha options that can be specified multiple times
 const MULTIPLE_OPTS = [
 	'require'
 ];

--- a/test/fixtures/fixture-require1.js
+++ b/test/fixtures/fixture-require1.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/test/fixtures/fixture-require2.js
+++ b/test/fixtures/fixture-require2.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/test/test.js
+++ b/test/test.js
@@ -61,4 +61,17 @@ describe('mocha()', () => {
 		stream.write(fixture('fixture-pass.js'));
 		stream.end();
 	});
+
+	it('should require two files', done => {
+		const stream = mocha({require: [
+      'test/fixtures/fixture-require1.js',
+      'test/fixtures/fixture-require2.js'
+    ]});
+		stream.once('_result', result => {
+			assert(/1 passing/.test(result.stdout));
+			done();
+		});
+		stream.write(fixture('fixture-pass.js'));
+		stream.end();
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -64,9 +64,10 @@ describe('mocha()', () => {
 
 	it('should require two files', done => {
 		const stream = mocha({require: [
-      'test/fixtures/fixture-require1.js',
-      'test/fixtures/fixture-require2.js'
-    ]});
+			'test/fixtures/fixture-require1.js',
+			'test/fixtures/fixture-require2.js'
+		]});
+
 		stream.once('_result', result => {
 			assert(/1 passing/.test(result.stdout));
 			done();


### PR DESCRIPTION
For multiple requires mocha wants multiple "--require <file>" switches.
Right now grunt-mocha sends --require file1,file2 to mocha instead of --require file1 --require file2

