### PR TITLE
Stop swallowing errors in mocha output

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,8 @@ If your test suite is not exiting it might be because you still have a lingering
 gulp.task('default', () =>
 	gulp.src('test.js')
 		.pipe(mocha())
-		.once('error', () => {
+		.once('error', (err) => {
+			console.error(err.stack);
 			process.exit(1);
 		})
 		.once('end', () => {


### PR DESCRIPTION
If you copy paste the last example in the README to your source code,
then try to run mocha on a file that contains a ReferenceError, you
get no output. This makes it hard to track down the original cause of
the problem. Fix this by logging an error reported by Mocha to the
screen before exiting the process.