### PR TITLE
Fix tests in Node 8

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -33,9 +33,7 @@ test('pass async AssertionError to mocha', async t => {
 	const event = pEvent(stream, 'error');
 	stream.end(fixture('fixture-async.js'));
 	const error = await event;
-	const throws = /throws after timeout/.test(error.stdout);
-	const uncaught = /Uncaught AssertionError: false == true/.test(error.stdout);
-	t.true(throws || uncaught);
+	t.regex(error.stdout, /throws after timeout|Uncaught AssertionError.*: false == true/);
 });
 
 test('require two files', async t => {


### PR DESCRIPTION
Node 8 added error codes to error messages. The error message in node8 is now `Uncaught AssertionError [ERR_ASSERTION]: false == true`

I also changed the tester from `t.true` to `t.regex`. This was done so that future error messages become can more meaningful. I had a little bit of difficulty parsing the error before as all that was reported to me was "the value false was expected to be true".

The regular expression used to check for the assertion error is a little broad with the wildcard match before the colon. If you'd like a more specific one, I can change it to this:
```
t.regex(error.stdout, /throws after timeout|Uncaught AssertionError( \[ERR_ASSERTION])?: false == true/);
```