### PR TITLE
Reduce noise in console output on test failures

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = opts => {
 			done();
 		})
 			.catch(err => {
-				this.emit('error', new PluginError('gulp-mocha', err));
+				this.emit('error', new PluginError('gulp-mocha', err.code > 0 ? 'There were test failures' : err));
 				done();
 			});
 


### PR DESCRIPTION
When a test is failing, an exception is reported to gulp-mocha that the process failed. This exception contains the console output both in the message and in its details. The result is that the failure details are logged three times to the console.

This change reduces the noise in the output on test failures.

Before:

```
$ ./node_modules/.bin/gulp test
[16:31:16] Using gulpfile ~/code/gulp-mocha-test/gulpfile.js
[16:31:16] Starting 'test'...


  test suite
    1) example test


  0 passing (5ms)
  1 failing

  1) test suite
       example test:
     Error: example test failure
      at Context.<anonymous> (test.js:3:15)



[16:31:16] 'test' errored after 230 ms
[16:31:16] Error in plugin "gulp-mocha"
Message:
    Command failed: mocha /Users/jb/code/gulp-mocha-test/test.js --colors



  test suite
    1) example test


  0 passing (5ms)
  1 failing

  1) test suite
       example test:
     Error: example test failure
      at Context.<anonymous> (test.js:3:15)




Details:
    code: 1
    killed: false
    stdout: 

  test suite
    1) example test


  0 passing (5ms)
  1 failing

  1) test suite
       example test:
     Error: example test failure
      at Context.<anonymous> (test.js:3:15)




    stderr: 
    failed: true
    signal: null
    cmd: mocha /Users/jb/code/gulp-mocha-test/test.js --colors
    timedOut: false

```

After:

```
$ ./node_modules/.bin/gulp test
[16:30:04] Using gulpfile ~/code/gulp-mocha-test/gulpfile.js
[16:30:04] Starting 'test'...


  test suite
    1) example test


  0 passing (5ms)
  1 failing

  1) test suite
       example test:
     Error: example test failure
      at Context.<anonymous> (test.js:3:15)



[16:30:04] 'test' errored after 229 ms
[16:30:04] Error in plugin "gulp-mocha"
Message:
    There were test failures
```