### PR TITLE
Set color option to what is supported by the current env

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const dargs = require('dargs');
 const execa = require('execa');
 const PluginError = require('plugin-error');
+const supportsColor = require('supports-color');
 const through = require('through2');
 // TODO: Use execa localDir option when available
 const npmRunPath = require('npm-run-path');
@@ -16,7 +17,7 @@ const MULTIPLE_OPTS = new Set([
 
 module.exports = opts => {
 	opts = Object.assign({
-		colors: true,
+		colors: !!supportsColor.stdout,
 		suppress: false
 	}, opts);
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const MULTIPLE_OPTS = new Set([
 
 module.exports = opts => {
 	opts = Object.assign({
-		colors: !!supportsColor.stdout,
+		colors: Boolean(supportsColor.stdout),
 		suppress: false
 	}, opts);
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"mocha": "^4.1.0",
 		"npm-run-path": "^2.0.2",
 		"plugin-error": "^0.1.2",
+		"supports-color": "^5.4.0",
 		"through2": "^2.0.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
By passing `colors: true` to mocha, colors will always be used, regardless of what the current tty supports. This means you get a bunch of garbage if for example piping the test output to a file.

This change will only pass `colors: true` to mocha if color is supported.