### PR TITLE
Fix regressions in v7

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ module.exports = options => {
 	function flush(done) {
 		(async () => {
 			const subprocess = execa('mocha', files.concat(args), {
-				localDir: __dirname
+				localDir: __dirname,
+				preferLocal: true
 			});
 
 			if (!options.suppress) {

--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ module.exports = options => {
 			});
 
 			if (!options.suppress) {
-				subprocess.stdout.pipe(subprocess.stdout);
-				subprocess.stderr.pipe(subprocess.stderr);
+				subprocess.stdout.pipe(process.stdout);
+				subprocess.stderr.pipe(process.stderr);
 			}
 
 			try {


### PR DESCRIPTION
The upgrade to version 7.0.0 makes now use of execa option `localDir`. The latter package does now the actual call to `npmRunPath`.

But in order for the change to be seemless in gulp-mocha, the option `preferLocal` when calling execa must be set to true, otherwise the arrow function `getEnv` in execa will ignore it.

Moreover `subprocess.stdout.pipe(subprocess.stdout);` looked suspicious to me. I checked against gulp-mocha@6 and it used to be piped into `process` stdios. So I replaced piping `subprocess` stdios into themselves by  their piping into `process` stdios. 

`npm run test` didn't show any error after the changes, the 4 tests still pass. 

Fixes #196