### PR TITLE
Upgrade mocha to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"dependencies": {
 		"dargs": "^7.0.0",
 		"execa": "^2.0.4",
-		"mocha": "^6.2.0",
+		"mocha": "^8.3.0",
 		"plugin-error": "^1.0.1",
 		"supports-color": "^7.0.0",
 		"through2": "^3.0.1"


### PR DESCRIPTION
In my case, I want gulp mocha task to use root hooks introduced in mocha 8.3.0. 

Upgrade mocha to 8.3.0 to support root hooks in gulp task.  mocha 8.3.0 requires Nodejs 10.12.0+

Since my understanding is gulp-mocha is a thin wrapper of mocha, I didn't see backwards compatibility issue.  